### PR TITLE
Fix#parse faulty param

### DIFF
--- a/readmeai/builder.py
+++ b/readmeai/builder.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Tuple
 
-from . import conf, factory, logger, utils
+import conf, factory, logger, utils
 
 LOGGER = logger.Logger(__name__)
 

--- a/readmeai/conf.py
+++ b/readmeai/conf.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse, urlsplit
 import openai
 from pydantic import BaseModel, Field, SecretStr, validator
 
-from . import factory, logger
+import factory, logger
 
 LOGGER = logger.Logger(__name__)
 

--- a/readmeai/main.py
+++ b/readmeai/main.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 import click
 
-from . import builder, conf, logger, model, preprocess
+import builder, conf, logger, model, preprocess
 
 logger = logger.Logger(__name__)
 config = conf.load_config()

--- a/readmeai/model.py
+++ b/readmeai/model.py
@@ -15,7 +15,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from . import conf, logger, utils
+import conf, logger, utils
 
 
 class OpenAIHandler:

--- a/readmeai/parse.py
+++ b/readmeai/parse.py
@@ -190,33 +190,24 @@ def parse_maven(content: str) -> List[str]:
     ]
 
 
-def parse_cmake(file_path: str) -> List[str]:
+def parse_cmake(content: str) -> List[str]:
     """Extracts dependencies from a CMakeLists.txt file."""
-    with open(file_path) as f:
-        content = f.read()
-
     regex = re.compile(r"add_executable\([^)]+\s+([^)]+)\)")
     package_names = regex.findall(content)
 
     return package_names
 
 
-def parse_configure_ac(file_path: str) -> List[str]:
+def parse_configure_ac(content: str) -> List[str]:
     """Extracts dependencies from a configure.ac file."""
-    with open(file_path) as f:
-        content = f.read()
-
     regex = re.compile(r"AC_CHECK_LIB\([^)]+\s+([^)]+)\)")
     package_names = regex.findall(content)
 
     return package_names
 
 
-def parse_makefile_am(file_path: str) -> List[str]:
+def parse_makefile_am(content: str) -> List[str]:
     """Extracts dependencies from a Makefile.am file."""
-    with open(file_path) as f:
-        content = f.read()
-
     regex = re.compile(r"bin_PROGRAMS\s*=\s*(.+)")
     package_names = []
     matches = regex.findall(content)

--- a/readmeai/parse.py
+++ b/readmeai/parse.py
@@ -7,7 +7,7 @@ from typing import List
 import toml
 import yaml
 
-from . import logger
+import logger
 
 LOGGER = logger.Logger(__name__)
 

--- a/readmeai/preprocess.py
+++ b/readmeai/preprocess.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 from typing import Dict, Generator, List, Tuple
 
-from . import conf, parse, utils
+import conf, parse, utils
 
 
 class RepositoryParserWrapper:

--- a/readmeai/utils.py
+++ b/readmeai/utils.py
@@ -7,7 +7,7 @@ from typing import List
 import git
 from tiktoken import get_encoding
 
-from . import conf
+import conf
 
 
 def clone_repository(url: str, repo_path: Path) -> None:


### PR DESCRIPTION
The last three parsers in parse.py are expecting a file_path instead of a file content, that raises an exception:

`def parse_cmake(file_path: str) -> List[str]`
`def parse_configure_ac(file_path: str) -> List[str]`
`def parse_makefile_am(file_path: str) -> List[str]`

**Fix:**
Change that to instead waiting for a content as parameter, that content is handled by the regex directly without intervention of a file reader. Works now.

