### PR TITLE
feat: Add CLI options for customizing OpenAI requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,11 +403,13 @@ To generate a *README.md* file, use the `readmeai` command in your terminal, alo
 
 | Short Flag | Long Flag      | Description                                       | Status       |
 |------------|----------------|---------------------------------------------------|--------------|
-| `-k`       | `--api-key`    | Your OpenAI API key.                              | Required     |
-| `-o`       | `--output`     | The output path for your README.md file.          | Required     |
+| `-k`       | `--api-key`    | Your OpenAI API secret key.                       | Required     |
+| `-e`       | `--engine`     | OpenAI GPT language model engine (gpt-3.5-turbo)  | Optional     |
+| `-o`       | `--output`     | The output path for your README.md file.          | Optional     |
 | `-r`       | `--repository` | The URL or path to your code repository.          | Required     |
-| `-t`       | `--template`   | The README template format to use. (coming soon!) | Coming Soon! |
+| `-t`       | `--temperature`| The temperature (randomness) of the model         | Optional     |
 | `-l`       | `--language`   | The language of text written in the README file.  | Coming Soon! |
+| `-s`       | `--style`      | The README template format to use. (coming soon!) | Coming Soon! |
 
 <br>
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1393,6 +1393,26 @@ files = [
 ]
 
 [[package]]
+name = "tornado"
+version = "6.3.3"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "tornado-6.3.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:502fba735c84450974fec147340016ad928d29f1e91f49be168c0a4c18181e1d"},
+    {file = "tornado-6.3.3-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:805d507b1f588320c26f7f097108eb4023bbaa984d63176d1652e184ba24270a"},
+    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bd19ca6c16882e4d37368e0152f99c099bad93e0950ce55e71daed74045908f"},
+    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ac51f42808cca9b3613f51ffe2a965c8525cb1b00b7b2d56828b8045354f76a"},
+    {file = "tornado-6.3.3-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71a8db65160a3c55d61839b7302a9a400074c9c753040455494e2af74e2501f2"},
+    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:ceb917a50cd35882b57600709dd5421a418c29ddc852da8bcdab1f0db33406b0"},
+    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:7d01abc57ea0dbb51ddfed477dfe22719d376119844e33c661d873bf9c0e4a16"},
+    {file = "tornado-6.3.3-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9dc4444c0defcd3929d5c1eb5706cbe1b116e762ff3e0deca8b715d14bf6ec17"},
+    {file = "tornado-6.3.3-cp38-abi3-win32.whl", hash = "sha256:65ceca9500383fbdf33a98c0087cb975b2ef3bfb874cb35b8de8740cf7f41bd3"},
+    {file = "tornado-6.3.3-cp38-abi3-win_amd64.whl", hash = "sha256:22d3c2fa10b5793da13c807e6fc38ff49a4f6e1e3868b0a6f4164768bb8e20f5"},
+    {file = "tornado-6.3.3.tar.gz", hash = "sha256:e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.66.1"
 description = "Fast, Extensible Progress Meter"
@@ -1561,4 +1581,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "9ad35cabfb93c146336d857e20fd77b797147200828a45479e818e8e92cd0064"
+content-hash = "c358cb0829781affc50e8638048a3210fc5308e4d55aab86774b3fda61c0d3cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "readmeai"
-version = "0.3.067"
+version = "0.3.068"
 description = "🚀 Generate beautiful README files automatically, powered by GPT-4 🪐"
 authors = ["Eli <0x.eli.64s@gmail.com>"]
 license = "MIT"
@@ -26,6 +26,7 @@ keywords = [
     'openai-api',
     'python',
     'readme',
+    'readme-badges',
     'readme-generation',
     'readme-generator'
 ]
@@ -50,6 +51,7 @@ tiktoken = "^0.4.0"
 toml = "^0.10.2"
 pydantic = "^1.10.9"
 click = "^8.1.6"
+tornado = "^6.3.3"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/readmeai/main.py
+++ b/readmeai/main.py
@@ -18,12 +18,9 @@ config_model = conf.AppConfigModel(app=config)
 config_helper = conf.load_config_helper(config_model)
 
 
-async def main(output: str, repository: str) -> None:
+async def main(repository: str) -> None:
     """Main entrypoint for the readme-ai application."""
     config.git = conf.GitConfig(repository=repository)
-    config.paths.readme = output
-    logger.info("Model: %s", dict(config.api, api_key="*" * 16))
-    logger.info("Repository: %s", config.git)
     llm = model.OpenAIHandler(config)
     await generate_readme(llm)
 
@@ -98,6 +95,12 @@ def get_dependencies(
     help="OpenAI API secret key.",
 )
 @click.option(
+    "-e",
+    "--engine",
+    default="gpt-3.5-turbo",
+    help="OpenAI language model engine to use.",
+)
+@click.option(
     "-o",
     "--output",
     default="readme-ai.md",
@@ -111,24 +114,42 @@ def get_dependencies(
 )
 @click.option(
     "-t",
-    "--template",
-    help="Template to use for README.md file.",
+    "--temperature",
+    default=0.9,
+    help="OpenAI's temperature parameter, a higher value increases randomness.",
 )
 @click.option(
     "-l",
     "--language",
     help="Language to write README.md file in.",
 )
+@click.option(
+    "-s",
+    "--style",
+    help="Template to use for README.md file.",
+)
 def cli(
     api_key: str,
-    output: str,
+    engine: Optional[str],
+    output: Optional[str],
     repository: str,
-    template: Optional[int],
+    temperature: Optional[float],
     language: Optional[str],
+    style: Optional[int],
 ) -> None:
     """Cli entrypoint for readme-ai pypi package."""
+    config.paths.readme = output
+    config.api.api_key = api_key
+    config.api.engine = engine
+    config.api.temperature = temperature
+
     logger.info("README-AI is now executing.")
-    asyncio.run(main(output, repository))
+    logger.info(f"Output file: {config.paths.readme}")
+    logger.info(f"OpenAI Engine: {config.api.engine}")
+    logger.info(f"OpenAI Temperature: {config.api.temperature}")
+
+    asyncio.run(main(repository))
+
     logger.info("README-AI execution complete.")
 
 


### PR DESCRIPTION
- Allow users to modify parameters for OpenAI API requests via CLI options.
- Added options include engine (i.e. gpt-4) and the sampling temperature.
- Improve user experience by offering flexibility in configuring OpenAI requests.