### PR TITLE
[FIX] Implement Custom Directory Tree Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ https://github.com/eli64s/readme-ai/assets/43382407/e8260e78-b684-4e72-941c-b304
     <tr>
         <h3>Directory Tree and File Summaries</h3>
         <p>
-            ‣ Your project's directory structure is visualized using the <i>tree</i> command.
+            ‣ Your project's directory structure is visualized using a custom tree function.
         </p>
         <p>
             ‣ Each file in the codebase is summarized by OpenAI's <i>GPT</i> model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "readmeai"
-version = "0.3.077"
+version = "0.3.078"
 description = "🚀 Generate beautiful README.md files from the terminal. Powered by OpenAI's GPT LLMs 💫"
 authors = ["Eli <0x.eli.64s@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "readmeai"
-version = "0.3.078"
+version = "0.3.079"
 description = "🚀 Generate beautiful README.md files from the terminal. Powered by OpenAI's GPT LLMs 💫"
 authors = ["Eli <0x.eli.64s@gmail.com>"]
 license = "MIT"

--- a/readmeai/main.py
+++ b/readmeai/main.py
@@ -37,7 +37,7 @@ async def generate_readme(llm: model.OpenAIHandler, offline: bool) -> None:
         config.md.tree = config.md.tree.format(tree)
         logger.info(f"Directory tree: {config.md.tree}")
 
-        scanner = preprocess.RepositoryParserWrapper(config, config_helper)
+        scanner = preprocess.RepositoryHandler(config, config_helper)
         dependencies, file_text = scanner.get_dependencies(temp_dir)
         logger.info(f"Dependencies: {dependencies}")
         logger.info(f"Total files: {len(file_text)}")

--- a/readmeai/main.py
+++ b/readmeai/main.py
@@ -33,7 +33,8 @@ async def generate_readme(llm: model.OpenAIHandler, offline: bool) -> None:
 
     try:
         temp_dir = utils.clone_repo_to_temp_dir(repository)
-        tree = builder.create_directory_tree(temp_dir)
+        tree_str = builder.generate_tree(temp_dir, repository)
+        tree = builder.format_tree(name, tree_str)
         config.md.tree = config.md.tree.format(tree)
         logger.info(f"Directory tree: {config.md.tree}")
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -12,7 +12,7 @@ find . -type d \( -name "__pycache__" \
                   -o -name ".vscode" \) -execdir rm -rf {} +
 
 # Remove build artifacts, pytest cache, and benchmarks
-rm -rf build/ dist/ *.egg-info/ .pytest_cache/ .benchmarks/
+rm -rf build/ dist/ -- *.egg-info/ .pytest_cache/ .benchmarks/
 
 # Remove specific files
 rm -rf docs/raw_data.csv *.log *.out *.rdb


### PR DESCRIPTION
The README's directory tree is now generated using pure Python.
- Removes dependency on the tree command keeping it native to Python
- Improves security by removing the subprocess module.

In the original implementation, if the desired executable path is not fully qualified relative to the filesystem root then this may present a potential security risk.

```py
def run_tree_command(repo_path: Path) -> str:
    """Executes the 'tree' command to generate a directory tree."""
    tree_bytes = subprocess.check_output(["tree", "-n", repo_path])
```

More details on this can be found [here](https://bandit.readthedocs.io/en/latest/plugins/b607_start_process_with_partial_path.html#b607-start-process-with-partial-path)

---