### PR TITLE
Adding Telnyx API for open source model support

### DIFF
--- a/readmeai/cli/options.py
+++ b/readmeai/cli/options.py
@@ -52,6 +52,7 @@ class ModelOptions(str, Enum):
     OLLAMA = "OLLAMA"
     OPENAI = "OPENAI"
     GEMINI = "GEMINI"
+    TELNYX = "TELNYX"
 
 
 def prompt_for_image(

--- a/readmeai/config/settings.py
+++ b/readmeai/config/settings.py
@@ -108,6 +108,8 @@ class ModelSettings(BaseModel):
     temperature: Optional[float]
     tokens: Optional[int]
     top_p: Optional[float]
+    telnyx_base_url: Optional[HttpUrl]
+    telnyx_base_model: Optional[str]
 
 
 class Settings(BaseModel):

--- a/readmeai/config/settings/config.toml
+++ b/readmeai/config/settings/config.toml
@@ -28,6 +28,8 @@ model = "gpt-3.5-turbo"
 temperature = 0.9
 tokens = 650
 top_p = 0.9
+telnyx_base_url = "https://api.telnyx.com/v2/ai/chat/completions"
+telnyx_base_model = "meta-llama/Meta-Llama-3-70B-Instruct"
 
 # Markdown Template Settings
 [md]

--- a/readmeai/core/utils.py
+++ b/readmeai/core/utils.py
@@ -19,6 +19,7 @@ class SecretKey(str, Enum):
     OLLAMA_HOST = "OLLAMA_HOST"
     OPENAI_API_KEY = "OPENAI_API_KEY"
     GOOGLE_API_KEY = "GOOGLE_API_KEY"
+    TELNYX_API_KEY = "TELNYX_API_KEY"
 
 
 def _set_offline(message: str) -> tuple:
@@ -33,12 +34,14 @@ def get_environment(llm_api: str = "", llm_model: str = "") -> tuple:
         llms.OPENAI.name: "gpt-3.5-turbo",
         llms.OLLAMA.name: "mistral",
         llms.GEMINI.name: "gemini-pro",
+        llms.TELNYX.name: "meta-llama/Meta-Llama-3-70B-Instruct",
     }
 
     env_keys = {
         llms.OPENAI.name: SecretKey.OPENAI_API_KEY.value,
         llms.OLLAMA.name: SecretKey.OLLAMA_HOST.value,
         llms.GEMINI.name: SecretKey.GOOGLE_API_KEY.value,
+        llms.TELNYX.name: SecretKey.TELNYX_API_KEY.value,
     }
 
     if llm_api and llm_api not in env_keys:
@@ -65,6 +68,15 @@ def get_environment(llm_api: str = "", llm_model: str = "") -> tuple:
     ):
         return _set_offline(
             "GOOGLE_API_KEY not found in environment. Switching to offline mode."
+        )
+
+    # If TELNYX_API_KEY does not exist in env when --api telnyx is set
+    if (
+        llm_api == llms.TELNYX.name
+        and SecretKey.TELNYX_API_KEY.value not in os.environ
+    ):
+        return _set_offline(
+            "TELNYX_API_KEY not found in environment. Switching to offline mode."
         )
 
     # If no specific API is provided or the provided API is valid

--- a/readmeai/models/factory.py
+++ b/readmeai/models/factory.py
@@ -19,6 +19,7 @@ class ModelFactory:
         llms.OLLAMA.value: OpenAIHandler,
         llms.OPENAI.value: OpenAIHandler,
         llms.GEMINI.value: GeminiHandler,
+        llms.TELNYX.value: OpenAIHandler,
     }
 
     @staticmethod

--- a/readmeai/models/openai.py
+++ b/readmeai/models/openai.py
@@ -48,6 +48,13 @@ class OpenAIHandler(BaseModelHandler):
             self.client = openai.OpenAI(
                 base_url=_localhost, api_key=llms.OLLAMA.name
             )
+        elif self.config.llm.api == llms.TELNYX.name:
+            self.endpoint = self.config.llm.telnyx_base_url
+            self.model = self.config.llm.telnyx_base_model
+            self.client = openai.OpenAI(
+                base_url=self.endpoint,
+                api_key=os.environ.get("TELNYX_API_KEY"),
+            )
         self.headers = {"Authorization": f"Bearer {self.client.api_key}"}
 
     async def _build_payload(self, prompt: str, tokens: int) -> dict:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -51,6 +51,18 @@ def test_offline_mode_when_no_env_vars_set(mock_configs):
     assert test_model == ModelOptions.OFFLINE.name
 
 
+@patch.dict("os.environ", {"TELNYX_API_KEY": "KEYXXX"}, clear=True)
+def test_get_environment_telnyx(mock_configs):
+    """Test that the environment is setup correctly for OpenAI."""
+    mock_configs.config.llm.api = ModelOptions.TELNYX.name
+    mock_configs.config.llm.model = "meta-llama/Meta-Llama-3-70B"
+    test_api, test_model = get_environment(
+        mock_configs.config.llm.api, mock_configs.config.llm.model
+    )
+    assert test_api == ModelOptions.TELNYX.name
+    assert test_model == "meta-llama/Meta-Llama-3-70B"
+
+
 @patch.dict("os.environ", {}, clear=True)
 def test_set_offline_mode(mock_configs):
     """Test that the environment is setup correctly for offline mode."""


### PR DESCRIPTION
This PR adds support for the Telnyx API, an OpenAI compatible API that serves a variety of open-source HuggingFace models like `meta-llama/Meta-Llama-3-70B` and `NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO`. 

Not a whole lot of changes needed to be made, namely just the addition of the `TELNYX_API_KEY` requirement for using that provider and the `telnyx_base_url` and `telnyx_base_model` config attributes.

Please let me know if you are open to this addition, as it opens up the possibility of testing out README generation performance with the latest open-source models. Thanks!