### PR TITLE
feat: Add model selection support for Anthropic handler #124

### DIFF
--- a/readmeai/models/anthropic.py
+++ b/readmeai/models/anthropic.py
@@ -40,7 +40,6 @@ class AnthropicHandler(BaseModelHandler):
     ) -> None:
         super().__init__(config_loader, context)
         self.client: Optional[Any] = None
-        self.model: str = "claude-3-opus-20240229"
         if ANTHROPIC_AVAILABLE:
             self._model_settings()
         else:
@@ -63,6 +62,7 @@ class AnthropicHandler(BaseModelHandler):
             return
 
         self.client = anthropic.AsyncAnthropic(api_key=api_key)
+        self.model = self.config.llm.model
 
     async def _build_payload(self, prompt: str, tokens: int) -> dict[str, Any]:
         """Build payload for POST request to the Anthropic API."""

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
@@ -22,6 +23,7 @@ def anthropic_handler(repository_context_fixture: RepositoryContext):
         pytest.skip("Anthropic library is not available")
     config_loader = ConfigLoader()
     context = repository_context_fixture
+    os.environ["ANTHROPIC_API_KEY"] = "test"
     return AnthropicHandler(config_loader, context)
 
 


### PR DESCRIPTION
The Anthropic handler currently uses a hardcoded model (claude-3-opus-20240229). This change allows model selection through configuration, matching the behavior of the OpenAI handler.

Changes:
- Remove hardcoded model string
- Use config loader to get model name from configuration
- Update model settings initialization

Fixes #124