### PR TITLE
fix: Update links to resolve MkDocs 404 errors (#128, #138).

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,7 +12,7 @@
       Designed for simplicity, customization, and developer productivity.
     </p>
     <div class="cta-buttons">
-      <a href="https://eli64s.github.io/readme-ai/usage/prerequisites/" class="button primary">
+      <a href="https://eli64s.github.io/readme-ai/getting-started/prerequisites/" class="button primary">
         Getting Started →
       </a>
       <a href="https://github.com/eli64s/readme-ai" class="button secondary">


### PR DESCRIPTION
This PR addresses the 404 errors reported in issues #128 and #138. Both issues stem from an outdated URL for ReadmeAI's getting started documentation page.

- Fixes #128 
- Closes #138 