### PR TITLE
Add optional OpenAI Codex OAuth mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ CLAUDE.md
 .version.tmp
 .github/workflows/update-badges-local.yml
 .github/workflows/update-badges.yml
+# Local auth artifacts
+readme-ai.md

--- a/README.md
+++ b/README.md
@@ -538,14 +538,45 @@ To start, follow these steps:
 
 ##### Running with a LLM API service
 
-Below is the minimal command required to run `readmeai` using the `OpenAI` client:
+Below is the minimal command required to run `readmeai` using the standard `OpenAI` API client:
 
 ```sh
 ❯ readmeai --api openai -o readmeai-openai.md -r https://github.com/eli64s/readme-ai
 ```
 
 > [!IMPORTANT]
-> The default model set is `gpt-3.5-turbo`, offering the best balance between cost and performance.When using any model from the `gpt-4` series and up, please monitor your costs and usage to avoid unexpected charges.
+> The default model set is `gpt-3.5-turbo`, offering the best balance between cost and performance. When using any model from the `gpt-4` series and up, please monitor your costs and usage to avoid unexpected charges.
+
+##### Optional: OpenAI Codex OAuth mode
+
+`readmeai` also supports an optional OpenAI Codex OAuth path for ChatGPT/Codex-backed access. This mode is separate from the normal `OPENAI_API_KEY` workflow and uses a Codex-specific backend.
+
+Log in once to store local OAuth credentials:
+
+```sh
+❯ readmeai --login-openai-codex
+```
+
+Check whether `readmeai` can currently resolve OpenAI credentials:
+
+```sh
+❯ readmeai --check-openai-auth
+```
+
+Probe the Codex backend with your stored OAuth credentials:
+
+```sh
+❯ readmeai --api openai --openai-auth-mode codex --model gpt-5.4 --probe-openai-codex
+```
+
+Generate a README using the Codex backend explicitly:
+
+```sh
+❯ readmeai --api openai --openai-auth-mode codex --model gpt-5.4 -o readmeai-codex.md -r https://github.com/eli64s/readme-ai
+```
+
+> [!NOTE]
+> Codex OAuth mode is optional and does **not** replace the existing API-key path. Standard OpenAI usage with `OPENAI_API_KEY` remains unchanged.
 
 ReadmeAI can easily switch between API providers and models. We can run the same command as above with the `Anthropic` client:
 ```sh
@@ -714,6 +745,7 @@ Customize your README generation with a variety of options and style settings su
 | `--repository`       | Repository URL or local directory path        | `None`          |
 | `--temperature`      | Creativity level for content generation       | `0.1`           |
 | `--tree-max-depth`   | Maximum depth of the directory tree structure | `2`             |
+| `--openai-auth-mode` | OpenAI auth path: `auto`, `api`, or `codex`  | `auto`          |
 
 Run the following command to view all available options:
 

--- a/readmeai/auth.py
+++ b/readmeai/auth.py
@@ -1,0 +1,127 @@
+"""Auth helpers for readme-ai.
+
+Supports the existing OPENAI_API_KEY flow plus an optional local
+OpenAI Codex OAuth credential file for bearer-token auth.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import click
+
+OPENAI_CODEX_AUTH_PATH_ENV = "READMEAI_OPENAI_AUTH_FILE"
+DEFAULT_OPENAI_CODEX_AUTH_PATH = Path.home() / ".config" / "readmeai" / "auth.json"
+
+
+def _expand_auth_path(path: str | os.PathLike[str] | None = None) -> Path:
+    raw = path or os.getenv(OPENAI_CODEX_AUTH_PATH_ENV) or str(DEFAULT_OPENAI_CODEX_AUTH_PATH)
+    return Path(raw).expanduser()
+
+
+def load_openai_codex_credentials(path: str | os.PathLike[str] | None = None) -> dict[str, Any] | None:
+    auth_path = _expand_auth_path(path)
+    if not auth_path.exists():
+        return None
+
+    data = json.loads(auth_path.read_text())
+    if not isinstance(data, dict):
+        return None
+
+    creds = data.get("openai-codex")
+    if not isinstance(creds, dict):
+        return None
+
+    if not creds.get("access"):
+        return None
+
+    return creds
+
+
+def save_openai_codex_credentials(creds: dict[str, Any], path: str | os.PathLike[str] | None = None) -> Path:
+    auth_path = _expand_auth_path(path)
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {}
+    if auth_path.exists():
+        try:
+            existing = json.loads(auth_path.read_text())
+            if isinstance(existing, dict):
+                payload = existing
+        except Exception:
+            payload = {}
+
+    payload["openai-codex"] = creds
+    auth_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return auth_path
+
+
+def refresh_openai_codex_credentials(path: str | os.PathLike[str] | None = None) -> dict[str, Any] | None:
+    creds = load_openai_codex_credentials(path)
+    if not creds:
+        return None
+
+    refresh = creds.get("refresh")
+    if not isinstance(refresh, str) or not refresh:
+        return None
+
+    from readmeai.oauth_openai_codex import refresh_openai_codex_oauth
+
+    refreshed = refresh_openai_codex_oauth(refresh)
+    account_id = creds.get("accountId")
+    if account_id and not refreshed.get("accountId"):
+        refreshed["accountId"] = account_id
+    save_openai_codex_credentials(refreshed, path)
+    return refreshed
+
+
+def get_openai_bearer_token() -> str | None:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return api_key
+
+    creds = load_openai_codex_credentials()
+    if creds:
+        expires = creds.get("expires")
+        if isinstance(expires, (int, float)) and time.time() * 1000 >= expires:
+            try:
+                creds = refresh_openai_codex_credentials() or creds
+            except Exception:
+                pass
+        access = creds.get("access")
+        if isinstance(access, str) and access:
+            return access
+
+    return None
+
+
+def auth_source_label() -> str:
+    if os.getenv("OPENAI_API_KEY"):
+        return "OPENAI_API_KEY"
+    if load_openai_codex_credentials():
+        return f"OpenAI Codex OAuth file ({_expand_auth_path()})"
+    return "none"
+
+
+def login_openai_codex(
+    path: str | os.PathLike[str] | None = None,
+    *,
+    open_browser: bool = True,
+) -> Path:
+    """Run the optional ChatGPT/Codex OAuth login flow.
+
+    Stores credentials in a local JSON file for readme-ai to reuse.
+    """
+
+    from readmeai.oauth_openai_codex import login_openai_codex_oauth
+
+    creds = login_openai_codex_oauth(open_browser=open_browser)
+    return save_openai_codex_credentials(creds, path)
+
+
+def print_login_success(auth_path: Path) -> None:
+    click.echo(f"Saved OpenAI Codex OAuth credentials to {auth_path}")

--- a/readmeai/cli/main.py
+++ b/readmeai/cli/main.py
@@ -1,10 +1,12 @@
 """Entrypoint for the command-line interface for readme-ai."""
 
 import click
+from readmeai.auth import auth_source_label, get_openai_bearer_token, login_openai_codex as login_openai_codex_flow, print_login_success
 from readmeai.cli import options
 from readmeai.config.settings import ConfigLoader, GitSettings
 from readmeai.core.logger import get_logger
 from readmeai.core.pipeline import readme_agent
+from readmeai.oauth_openai_codex import probe_openai_codex_responses
 
 config = ConfigLoader()
 logger = get_logger(__name__)
@@ -25,11 +27,15 @@ logger = get_logger(__name__)
 @options.badge_color
 @options.badge_style
 @options.base_url
+@options.openai_auth_mode
 @options.context_window
 @options.emojis
 @options.header_style
 @options.logo
 @options.logo_size
+@options.login_openai_codex
+@options.check_openai_auth
+@options.probe_openai_codex
 @options.model
 @options.navigation_style
 @options.output
@@ -45,11 +51,15 @@ def main(
     badge_color: str,
     badge_style: str,
     base_url: str,
+    openai_auth_mode: str,
     context_window: int,
     emojis: bool,
     header_style: str,
     logo: str,
     logo_size: str,
+    login_openai_codex: bool,
+    check_openai_auth: bool,
+    probe_openai_codex: bool,
     model: str,
     navigation_style: str,
     output: str,
@@ -61,12 +71,33 @@ def main(
     tree_max_depth: int,
 ) -> None:
     """Entry point for the readme-ai CLI application."""
+    if login_openai_codex:
+        auth_path = login_openai_codex_flow()
+        print_login_success(auth_path)
+        return
+
+    if check_openai_auth:
+        token = get_openai_bearer_token()
+        click.echo(f"OpenAI auth source: {auth_source_label()}")
+        click.echo(f"OpenAI token available: {'yes' if token else 'no'}")
+        return
+
+    if probe_openai_codex:
+        token = get_openai_bearer_token()
+        if not token:
+            raise click.ClickException("No OpenAI token found. Set OPENAI_API_KEY or run --login-openai-codex first.")
+        result = probe_openai_codex_responses(token, model=model or 'gpt-4o-mini')
+        click.echo(f"Codex probe status: {result['status']}")
+        click.echo(str(result['body']))
+        return
+
     config.config.git = GitSettings(repository=repository)
 
     config.config.llm = config.config.llm.model_copy(
         update={
             "api": api,
             "base_url": base_url,
+            "openai_auth_mode": openai_auth_mode,
             "context_window": context_window,
             "model": model,
             "rate_limit": rate_limit,

--- a/readmeai/cli/options.py
+++ b/readmeai/cli/options.py
@@ -211,3 +211,31 @@ tree_max_depth = click.option(
     type=int,
     help="Maximum depth of the directory tree generated for the README file.",
 )
+
+login_openai_codex = click.option(
+    "--login-openai-codex",
+    is_flag=True,
+    help="Run a minimal ChatGPT/OpenAI Codex OAuth login and store credentials for reuse.",
+)
+
+check_openai_auth = click.option(
+    "--check-openai-auth",
+    is_flag=True,
+    help="Inspect whether OpenAI auth is available via API key or stored OAuth credentials.",
+)
+
+
+probe_openai_codex = click.option(
+    "--probe-openai-codex",
+    is_flag=True,
+    default=False,
+    help="Probe the ChatGPT/Codex backend with the stored OAuth token.",
+)
+
+openai_auth_mode = click.option(
+    "--openai-auth-mode",
+    type=click.Choice(["auto", "api", "codex"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Choose OpenAI auth/request mode: normal API, Codex OAuth backend, or auto.",
+)

--- a/readmeai/config/settings.py
+++ b/readmeai/config/settings.py
@@ -209,6 +209,7 @@ class ModelSettings(BaseModel):
     top_p: NonNegativeFloat = Field(default=0.9, le=1.0)
     rate_limit: PositiveInt = Field(default=10, le=30)
     resource: str = "v1/chat/completions"
+    openai_auth_mode: Literal["auto", "api", "codex"] = "auto"
     system_message: str = (
         "You're a 10x Staff Software Engineering leader, with deep knowledge "
         "across most tech stacks. You'll use your expertise to write robust "

--- a/readmeai/models/openai.py
+++ b/readmeai/models/openai.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import aiohttp
 import openai
+from readmeai.auth import get_openai_bearer_token, load_openai_codex_credentials
+from readmeai.oauth_openai_codex import get_openai_codex_session_headers
 from readmeai.config.settings import ConfigLoader
 from readmeai.extractors.models import RepositoryContext
 from readmeai.models.base import BaseModelHandler
@@ -37,22 +39,62 @@ class OpenAIHandler(BaseModelHandler):
         self.top_p = self.config.llm.top_p
 
         if self.config.llm.api == LLMProviders.OPENAI.value:
-            self.url = f"{self.host_name}{self.resource}"
-            if os.getenv("OPENAI_API_KEY") is None:
-                raise ValueError("OpenAI API key not set in environment.")
-            self.client = openai.OpenAI()
+            self.standard_url = str(self.config.llm.base_url or f"{self.host_name}{self.resource}")
+            self.url = self.standard_url
+            token = get_openai_bearer_token()
+            if token is None:
+                raise ValueError(
+                    "OpenAI credentials not found. Set OPENAI_API_KEY or login with `readmeai --login-openai-codex`."
+                )
+            self.client = openai.OpenAI(api_key=token)
+            mode = self.config.llm.openai_auth_mode
+            has_oauth = bool(load_openai_codex_credentials())
+            has_api = bool(os.getenv('OPENAI_API_KEY'))
+            self.using_oauth_codex = (mode == 'codex' and has_oauth) or (mode == 'auto' and has_oauth and not has_api)
+            if self.using_oauth_codex:
+                self.codex_url = 'https://chatgpt.com/backend-api/codex/responses'
+                if not self.config.llm.base_url or 'api.openai.com' in str(self.config.llm.base_url):
+                    self.url = self.codex_url
 
         elif self.config.llm.api == LLMProviders.OLLAMA.value:
-            self.url = f"{self.localhost}{self.resource}"
+            self.standard_url = f"{self.localhost}{self.resource}"
+            self.url = self.standard_url
             self.client = openai.OpenAI(
                 base_url=f"{self.localhost}v1",
                 api_key=LLMProviders.OLLAMA.name,
             )
 
         self.headers = {"Authorization": f"Bearer {self.client.api_key}"}
+        if getattr(self, 'using_oauth_codex', False):
+            creds = load_openai_codex_credentials() or {}
+            self.headers = get_openai_codex_session_headers(self.client.api_key, creds.get('accountId'))
+
+    def _effective_model(self) -> str:
+        if not getattr(self, 'using_oauth_codex', False):
+            return self.model
+        preferred = self.model
+        if preferred in {'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.2', 'gpt-5.1', 'gpt-5.1-codex-mini'}:
+            return preferred
+        return 'gpt-5.4'
 
     async def _build_payload(self, prompt: str) -> dict[str, Any]:
         """Build request body for making text generation requests."""
+        if getattr(self, 'using_oauth_codex', False):
+            reasoning_effort = 'low'
+            text_verbosity = 'medium'
+            return {
+                'model': self._effective_model(),
+                'instructions': self.system_message,
+                'input': [
+                    {'role': 'user', 'content': [{'type': 'input_text', 'text': prompt}]},
+                ],
+                'store': False,
+                'stream': True,
+                'tool_choice': 'auto',
+                'parallel_tool_calls': True,
+                'text': {'verbosity': text_verbosity},
+                'reasoning': {'effort': reasoning_effort, 'summary': 'auto'},
+            }
         return {
             "messages": [
                 {
@@ -109,12 +151,43 @@ class OpenAIHandler(BaseModelHandler):
                 headers=self.headers,
                 json=parameters,
             ) as response:
+                if response.status >= 400 and getattr(self, 'using_oauth_codex', False) and self.url.startswith('https://chatgpt.com/backend-api/codex/responses'):
+                    err_raw = await response.text()
+                    raise ValueError(f"Codex backend error {response.status}: {err_raw[:2000]}")
                 response.raise_for_status()
-                response = await response.json()
-                content = response["choices"][0]["message"]["content"]
+                if getattr(self, 'using_oauth_codex', False) and self.url.startswith('https://chatgpt.com/backend-api/codex/responses'):
+                    raw = await response.text()
+                    content = None
+                    for line in raw.splitlines():
+                        if line.startswith('data: '):
+                            import json as _json
+                            try:
+                                evt = _json.loads(line[6:])
+                            except Exception:
+                                continue
+                            if evt.get('type') == 'response.output_text.delta':
+                                delta = evt.get('delta')
+                                if isinstance(delta, str):
+                                    content = (content or '') + delta
+                            elif evt.get('type') == 'response.completed':
+                                resp = evt.get('response', {})
+                                output = resp.get('output', [])
+                                chunks = []
+                                for item in output:
+                                    for c in item.get('content', []):
+                                        txt = c.get('text')
+                                        if isinstance(txt, str):
+                                            chunks.append(txt)
+                                if chunks and not content:
+                                    content = ''.join(chunks)
+                    if not content:
+                        raise ValueError(f'Empty Codex response. Raw: {raw[:1000]}')
+                else:
+                    response = await response.json()
+                    content = response["choices"][0]["message"]["content"]
 
-                if not content:
-                    raise ValueError("Empty response from API")
+                    if not content:
+                        raise ValueError("Empty response from API")
 
                 self._logger.info(
                     f"Response from {self.config.llm.api.capitalize()} for '{index}': {content}",

--- a/readmeai/oauth_openai_codex.py
+++ b/readmeai/oauth_openai_codex.py
@@ -1,0 +1,256 @@
+"""OpenAI Codex OAuth helpers for readme-ai.
+
+These helpers support an optional ChatGPT/Codex-backed OpenAI auth mode
+without changing the existing standard OpenAI API-key workflow.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import urlencode, urlparse, parse_qs
+
+import httpx
+
+import click
+
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+REDIRECT_URI = "http://localhost:1455/auth/callback"
+SCOPE = "openid profile email offline_access"
+JWT_CLAIM_PATH = "https://api.openai.com/auth"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def generate_pkce() -> tuple[str, str]:
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    return verifier, challenge
+
+
+def create_state() -> str:
+    return secrets.token_hex(16)
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any] | None:
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = parts[1]
+        padding = "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload + padding)
+        import json
+        return json.loads(decoded)
+    except Exception:
+        return None
+
+
+def get_account_id(access_token: str) -> str | None:
+    payload = decode_jwt_payload(access_token)
+    if not payload:
+        return None
+    auth = payload.get(JWT_CLAIM_PATH)
+    if isinstance(auth, dict):
+        account_id = auth.get("chatgpt_account_id")
+        if isinstance(account_id, str) and account_id:
+            return account_id
+    return None
+
+
+def build_auth_url(verifier: str, state: str) -> str:
+    _, challenge = verifier, _b64url(hashlib.sha256(verifier.encode()).digest())
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "originator": "pi",
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+def _token_exchange(payload: dict[str, str]) -> dict[str, Any]:
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        response = client.post(
+            TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data=payload,
+        )
+    response.raise_for_status()
+    data = response.json()
+    access = data.get("access_token")
+    refresh = data.get("refresh_token")
+    expires_in = data.get("expires_in")
+    if not access or not refresh or not isinstance(expires_in, int):
+        raise RuntimeError("OAuth token response missing fields")
+    account_id = get_account_id(access)
+    if not account_id:
+        raise RuntimeError("Failed to extract ChatGPT account ID from token")
+    return {
+        "access": access,
+        "refresh": refresh,
+        "expires": int(__import__('time').time() * 1000) + (expires_in * 1000),
+        "accountId": account_id,
+    }
+
+
+def exchange_code(code: str, verifier: str) -> dict[str, Any]:
+    return _token_exchange(
+        {
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": code,
+            "code_verifier": verifier,
+            "redirect_uri": REDIRECT_URI,
+        }
+    )
+
+
+def refresh_openai_codex_oauth(refresh_token: str) -> dict[str, Any]:
+    return _token_exchange(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLIENT_ID,
+        }
+    )
+
+
+def get_openai_codex_session_headers(access_token: str, account_id: str | None = None, session_id: str | None = None) -> dict[str, str]:
+    account_id = account_id or get_account_id(access_token)
+    if not account_id:
+        raise RuntimeError("Failed to extract ChatGPT account ID from token")
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "chatgpt-account-id": account_id,
+        "OpenAI-Beta": "responses=experimental",
+        "originator": "pi",
+        "User-Agent": "readme-ai",
+        "accept": "application/json, text/event-stream",
+        "content-type": "application/json",
+    }
+    if session_id:
+        headers["session_id"] = session_id
+    return headers
+
+
+def probe_openai_codex_responses(access_token: str, model: str = "gpt-4o-mini") -> dict[str, Any]:
+    account_id = get_account_id(access_token)
+    url = "https://chatgpt.com/backend-api/codex/responses"
+    payload = {
+        "model": model,
+        "instructions": "You are a precise assistant. Follow the user exactly.",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Reply with exactly: pong"}]}],
+        "reasoning": {"effort": "low", "summary": "auto"},
+        "text": {"verbosity": "low"},
+        "store": False,
+        "stream": True,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+    }
+    headers = get_openai_codex_session_headers(access_token, account_id)
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        resp = client.post(url, headers=headers, json=payload)
+        try:
+            body = resp.json()
+        except Exception:
+            body = resp.text
+        return {"status": resp.status_code, "body": body, "headers": dict(resp.headers)}
+
+
+def probe_openai_codex_candidates(access_token: str, models: list[str]) -> list[dict[str, Any]]:
+    results = []
+    for model in models:
+        try:
+            result = probe_openai_codex_responses(access_token, model=model)
+            results.append({"model": model, **result})
+        except Exception as e:
+            results.append({"model": model, "status": "exception", "body": repr(e), "headers": {}})
+    return results
+
+
+def login_openai_codex_oauth(*, open_browser: bool = True) -> dict[str, Any]:
+    verifier, _challenge = generate_pkce()
+    state = create_state()
+    auth_url = build_auth_url(verifier, state)
+
+    code_holder: dict[str, str | None] = {"code": None}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/auth/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            if (params.get("state", [None])[0]) != state:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"State mismatch")
+                return
+            code = params.get("code", [None])[0]
+            if not code:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Missing code")
+                return
+            code_holder["code"] = code
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"<html><body><p>Authentication successful. Return to your terminal.</p></body></html>")
+
+        def log_message(self, format, *args):
+            return
+
+    click.echo("Starting OpenAI Codex OAuth login for readme-ai...")
+    click.echo(auth_url)
+    if open_browser and not os.getenv("READMEAi_NO_BROWSER"):
+        try:
+            webbrowser.open(auth_url)
+        except Exception:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 1455), Handler)
+    server.timeout = 120
+    try:
+        while not code_holder["code"]:
+            server.handle_request()
+            if not code_holder["code"]:
+                pass
+    finally:
+        server.server_close()
+
+    code = code_holder["code"]
+    if not code:
+        pasted = click.prompt("Paste the authorization code or full redirect URL", default="", show_default=False)
+        if "code=" in pasted:
+            parsed = urlparse(pasted)
+            params = parse_qs(parsed.query)
+            if (params.get("state", [None])[0]) not in (None, state):
+                raise RuntimeError("State mismatch")
+            code = params.get("code", [None])[0]
+        else:
+            code = pasted.strip() or None
+
+    if not code:
+        raise RuntimeError("Missing authorization code")
+
+    return exchange_code(code, verifier)


### PR DESCRIPTION
## Summary

Adds an optional OpenAI Codex OAuth path to `readmeai` without changing the existing standard OpenAI API-key workflow.

## What’s included

- optional Codex OAuth login flow
- local auth storage helpers
- auth inspection command
- Codex probe command
- explicit `--openai-auth-mode {auto,api,codex}`
- config support for `openai_auth_mode`
- Codex-specific backend routing only when Codex mode is selected
- standard OpenAI mode remains unchanged

## Notes

- This does not replace the normal `OPENAI_API_KEY` path.
- Codex mode uses a different backend/request shape than standard OpenAI chat completions.
- README quality / file-selection issues are intentionally out of scope for this PR.

## Validation

- login flow stores reusable local credentials
- auth check reports available auth source
- Codex probe confirms backend/model compatibility
- standard mode remains available
- Codex mode successfully completed smoke-test generation